### PR TITLE
Reset extension variable to allow for periods.

### DIFF
--- a/src/FileSystem.cpp
+++ b/src/FileSystem.cpp
@@ -153,6 +153,7 @@ namespace cabba { namespace filesystem {
             if (str[i] == '.')
             {
                 start_ext = true;
+                ext.clear(); // Reset extension
             }
         }
         char* newStr = new char[ext.size() + 1];


### PR DESCRIPTION
Reset the ext variable to allow for multiple periods in file path without causing any extra overhead.

The current extension method has a unexpected issue that arises from paths with multiple periods like for example `c:\\images\\.minecraft\\test.jpeg` will return `minecraft\test.jpeg`. A fix for this is just to clear the ext string each time a new period is discovered in the string.

## Tests
**_Test output:_**
```
Original function: 
test.jpeg
jpeg
minecraft\test.jpeg

Function with reset variable: 
jpeg
jpeg
jpeg
```

**_Test code:_** 
```cpp
// Example program
#include <iostream>
#include <string>
#include <windows.h>
#include <strsafe.h>
#include <filesystem>
#include <string>

#include <fstream>
char* original_extension(const char* path);
char* fixed_extension(const char* path);

int main()
{
    std::cout << "Original function: " << std::endl;
    std::cout << original_extension("c:\\image.test.jpeg") << std::endl;
    std::cout << original_extension("c:\\image.jpeg") << std::endl;
    std::cout << original_extension("c:\\images\\.minecraft\\test.jpeg") << std::endl << std::endl;

    std::cout << "Function with reset variable: " << std::endl;
    std::cout << fixed_extension("c:\\image.test.jpeg") << std::endl;
    std::cout << fixed_extension("c:\\image.jpeg") << std::endl;
    std::cout << fixed_extension("c:\\images\\.minecraft\\test.jpeg") << std::endl;
}

char* original_extension(const char* path)
{
    std::string str(path);
    std::string ext = "";
    bool start_ext = false;

    for (size_t i = 0; i < str.size(); ++i)
    {
        if (start_ext)
        {
            ext += str[i];
        }
        if (str[i] == '.')
        {
            start_ext = true;
        }
    }
    char* newStr = new char[ext.size() + 1];
    std::strcpy(newStr, ext.data());
    return newStr;
}

char* fixed_extension(const char* path)
{
    std::string str(path);
    std::string ext = "";
    bool start_ext = false;

    for (size_t i = 0; i < str.size(); ++i)
    {
        if (start_ext)
        {
            ext += str[i];
        }
        if (str[i] == '.')
        {
            start_ext = true;
            ext.clear();
        }
    }
    char* newStr = new char[ext.size() + 1];
    std::strcpy(newStr, ext.data());
    return newStr;
}
```